### PR TITLE
Remove H3+ from the default EOS species list

### DIFF
--- a/issue.md
+++ b/issue.md
@@ -1,0 +1,19 @@
+# SMElib Notes
+
+## EOS default list and placeholder molecular partition functions
+
+`H3+` should not be included in the default EOS species list.
+
+In the current EOS implementation, enabling `H3+` in the default network can
+drive the solution toward significantly larger `XNE`, `H-`, and `AHMIN`, which
+in turn makes Balmer lines much too shallow for cool-star cases such as
+Gmb1830.
+
+The immediate practical workaround is to keep `H3+` out of the default EOS
+list unless its thermodynamic treatment is revisited.
+
+Related note: `MOLCON` still contains many species with placeholder-style
+partition-function coefficients (for example constant `Q` behavior from
+`PCOEF = 1.0, 9*0.`-type entries). These species should be audited
+systematically, especially hydrogen-bearing and charged molecules that can
+affect the electron balance.

--- a/src/eos/DEFAULT.EOS.current
+++ b/src/eos/DEFAULT.EOS.current
@@ -16,7 +16,7 @@ C  i=where(strmid(a,0,1) ne 'c') & a=a[i]
 C  help,where(byte(a) eq (byte(','))[0], ndef)
 C  print,'parameter (NDEF='+strtrim(ndef+1,2)+')'
 C
-      parameter (NDEF=317)
+      parameter (NDEF=316)
       character*(SPCHAR) default(NDEF)
       SAVE default
       data default/
@@ -60,7 +60,7 @@ c     * 'SiF',      'C3',      'MgO2H2','BeOH','HBS','SiC2',
 c     * 'CHF',      'AlO2','BaO2H2','OTiF',      'C2N2',
      * 'SrO2H2','ClCN','AlClF','KCN','AlCl2','BaCl2','AlF2',
      * 'MgCl2',
-     * 'FeO-','H3+',
+     * 'FeO-',
      * 'BO2H2','SiH3Cl','FeCl2','Si3','SiH3F','CH3Cl',
      * 'SrCl2','CaF2','TiF2','LiBO2','MgClF','BeBO2','C2HCl',
      * 'TiCl2','C4','H3BO3','MgF2','BaClF','BeF2','C2HF',


### PR DESCRIPTION
## Summary

Remove `H3+` from the default EOS species list.

## Motivation

`H3+` in the default EOS network drives unrealistically large `XNE`, `H-`, and
`AHMIN` in cool-star cases, which makes Balmer lines too shallow.

## Notes

- This PR only removes `H3+` from the default EOS list.
- A short maintenance note was added to `issue.md` for future EOS cleanup.